### PR TITLE
feat: remove valueExt

### DIFF
--- a/libevmasm/Instruction.cpp
+++ b/libevmasm/Instruction.cpp
@@ -321,7 +321,7 @@ static std::map<Instruction, InstructionInfo> const c_instructionInfo =
 	{ Instruction::DELEGATECALL,	{ "DELEGATECALL",	0, 6, 1, true, Tier::Special } },
 	{ Instruction::STATICCALL,	{ "STATICCALL",		0, 6, 1, true, Tier::Special } },
 	{ Instruction::AUTH,        { "AUTH",			0, 3, 1, true, Tier::Special } },
-	{ Instruction::AUTHCALL,    { "AUTHCALL",		0, 8, 1, true, Tier::Special } },
+	{ Instruction::AUTHCALL,    { "AUTHCALL",		0, 7, 1, true, Tier::Special } },
 	{ Instruction::CREATE2,		{ "CREATE2",		0, 4, 1, true, Tier::Special } },
 	{ Instruction::REVERT,		{ "REVERT",		0, 2, 0, true, Tier::Zero } },
 	{ Instruction::INVALID,		{ "INVALID",		0, 0, 0, true, Tier::Zero } },

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2765,12 +2765,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 		m_context << Instruction::DUP2;
 	}
 
-	// Append `0` to the stack for `AUTHCALL`'s `valueExt`.
-	// The EIP-3074 spec says that the `valueExt` parameter is always supposed to be `0`.
-	if (isAuthCall)
-		m_context << u256(0);
-
-	// CALL arguments: outSize, outOff, inSize, inOff, [valueExt (if AUTHCALL)] (already present up to here)
+	// CALL arguments: outSize, outOff, inSize, inOff, (already present up to here)
 	// [value,] addr, gas (stack top)
 	if (isDelegateCall)
 		solAssert(!_functionType.valueSet(), "Value set for delegatecall");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2738,23 +2738,13 @@ void IRGeneratorForStatements::appendBareCall(
 			let <length> := mload(<arg>)
 		</needsEncoding>
 
-		let <success> := <call>(<gas>, <address>, <?+value> <value>, </+value> <?+valueExt> <valueExt>, </+valueExt> <pos>, <length>, 0, 0)
+		let <success> := <call>(<gas>, <address>, <?+value> <value>, </+value> <pos>, <length>, 0, 0)
 		let <returndataVar> := <extractReturndataFunction>()
 	)");
 
 	templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
 	templ("pos", m_context.newYulVariable());
 	templ("length", m_context.newYulVariable());
-
-	if (funKind == FunctionType::Kind::BareAuthCall)
-	{
-		// Currently, in the EIP-3074 spec, `valueExt` is always 0 for `AUTHCALL`.
-		templ("valueExt", "0");
-	}
-	else
-	{
-		templ("valueExt", "");
-	}
 
 	templ("arg", IRVariable(*_arguments.front()).commaSeparatedList());
 	Type const& argType = type(*_arguments.front());


### PR DESCRIPTION
Removes the `valueExt` argument from the `authcall` opcode, as it's no longer a part of EIP 3074.